### PR TITLE
Propagate exit code on Windows

### DIFF
--- a/exec_wrappers/templates/conda/run-in.bat
+++ b/exec_wrappers/templates/conda/run-in.bat
@@ -17,6 +17,5 @@
 )
 
 @REM Execute the given command
+@REM Nothing must be present after that line (not even a @REM), see issue #30
 __COMMAND__%*
-
-@endlocal

--- a/exec_wrappers/templates/virtualenv/run-in.bat
+++ b/exec_wrappers/templates/virtualenv/run-in.bat
@@ -7,6 +7,5 @@
 @set "PATH=%VIRTUAL_ENV%\Scripts;%PATH%"
 
 @rem Execute the given command
+@rem Nothing must be present after that line (not even a @rem), see issue #30
 __COMMAND__%*
-
-@endlocal

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -203,9 +203,9 @@ def _activate_conda_script():
 
 def _environ_from_wrapper():
     python_wrapper = os.path.normpath("wrappers/python") + get_wrapper_extension()
-    try:
-        # Return a non-zero exit code on purpose, to ensure wrapper forwards it.
-        output = subprocess.check_output(
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        # Return a non-zero exit code on purpose, to make sure wrapper returns it.
+        subprocess.check_output(
             [
                 python_wrapper,
                 "-c",
@@ -213,12 +213,8 @@ def _environ_from_wrapper():
                 "; import sys; sys.exit(42)",
             ]
         )
-        assert False, "Exit code not propagated (expected 42, got 0)"
-    except subprocess.CalledProcessError as e:
-        assert (
-            e.returncode == 42
-        ), "Exit code not propagated (expected 42, got {0})".format(e.returncode)
-        output = e.output
+    assert exc_info.value.returncode == 42
+    output = exc_info.value.output
     environ_from_wrapper = eval(output)
     return environ_from_wrapper
 


### PR DESCRIPTION
Fixes #30.

`endlocal` is not actually required at the end of `run-in.bat`, it's [documented](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/endlocal) as being implicit at the end of a batch file.

Having nothing after the wrapped command seems to be enough for its exit code to propagate. I added a comment describing that the wrapped command should be the last line.  
I updated conda & virtualenv integration tests to test this.

Note: if something needed to be added at the end of `run-in.bat`, another approach might be to capture %ERRORLEVEL% right after command invocation, and add an explicit `exit /B` with that value at the very end (not tested).
